### PR TITLE
Implement ability to configure VSCode variant

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	TerminalDefaultCommand string   `yaml:"terminal_default_command"`
 	VscodeDefaultService   string   `yaml:"vscode_default_service"`
 	VscodeDefaultDir       string   `yaml:"vscode_default_dir"`
+	VscodeVariant          string   `yaml:"vscode_variant"`
 	AwsLogin               bool     `yaml:"aws_login"`
 	AwsRegion              string   `yaml:"aws_region"`
 	AwsRepository          string   `yaml:"aws_repository"`
@@ -123,6 +124,7 @@ func (c *Config) ShowConfig() error {
 	fmt.Println("Terminal default command:", c.TerminalDefaultCommand)
 	fmt.Println("VSCode default service:", c.VscodeDefaultService)
 	fmt.Println("VSCode default directory:", c.VscodeDefaultDir)
+	fmt.Println("VSCode variant:", c.VscodeVariant)
 	fmt.Println()
 	fmt.Println("Show executed commands:", c.ShowExecutedCommands)
 	return nil

--- a/docker/vscode.go
+++ b/docker/vscode.go
@@ -8,12 +8,17 @@ import (
 	"github.com/marcinhlybin/docker-env/logger"
 )
 
-func (dc *DockerCmd) OpenCode(c *Container, dir string) error {
+func (dc *DockerCmd) OpenCode(c *Container, dir string, variant string) error {
+	// Set a default value for variant if it is empty
+	if variant == "" {
+		variant = "code"
+	}
+
 	// Encode the container name to hexadecimal
 	encodedName := hex.EncodeToString([]byte(c.Name))
 
 	// Format the command with the encoded container name and directory
-	command := fmt.Sprintf("code --folder-uri=vscode-remote://attached-container+%s/%s", encodedName, dir)
+	command := fmt.Sprintf("%s --folder-uri=vscode-remote://attached-container+%s/%s", variant, encodedName, dir)
 
 	// Use shell to exeucute the command
 	cmd := exec.Command("/bin/sh", "-c", command)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -199,7 +199,9 @@ func (reg *DockerProjectRegistry) Code(p *project.Project, dir string) error {
 		return nil
 	}
 
-	return reg.dockerCmd.OpenCode(container, dir)
+	variant := reg.Config.VscodeVariant
+
+	return reg.dockerCmd.OpenCode(container, dir, variant)
 }
 
 func (reg *DockerProjectRegistry) Logs(p *project.Project, opts docker.LogsOptions) error {


### PR DESCRIPTION
This allows you to configure which version of VSCode is started with the `docker-env code` command.
By settings this to `code` it will start the normal version of VSCode, but by setting it to `cursor` you can instead start the Cursor editor, which is based on VSCode.